### PR TITLE
Fix multiple bugs for F32

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,27 +23,27 @@ One way to test these is to install them on your system
 ```
 * then install the base
 ```bash    
-    dnf install f31-backgrounds-base-32.0.0-1.fc31.noarch.rpm
+    dnf install f32-backgrounds-base-32.0.0-1.fc31.noarch.rpm
 ```
 * finally install backgrounds for your desktop, for example for KDE 
 ```bash
-    dnf install f31-backgrounds-kde-32.0.0-1.fc31.noarch.rpm
+    dnf install f32-backgrounds-kde-32.0.0-1.fc31.noarch.rpm
 ```
 
 The directory should also contain the following rpms
 
-   * f32-backgrounds-32.0.0-1.fc31.noarch.rpm              
-   * f31-backgrounds-extras-gnome-32.0.0-1.fc31.noarch.rpm  
-   * f31-backgrounds-gnome-32.0.0-1.fc31.noarch.rpm
-   * f31-backgrounds-animated-32.0.0-1.fc31.noarch.rpm     
-   * f31-backgrounds-extras-kde-32.0.0-1.fc31.noarch.rpm    
-   * f31-backgrounds-kde-32.0.0-1.fc31.noarch.rpm
-   * f31-backgrounds-base-32.0.0-1.fc31.noarch.rpm         
-   * f31-backgrounds-extras-mate-32.0.0-1.fc31.noarch.rpm   
-   * f31-backgrounds-mate-32.0.0-1.fc31.noarch.rpm
-   * f31-backgrounds-extras-base-32.0.0-1.fc31.noarch.rpm  
-   * f31-backgrounds-extras-xfce-32.0.0-1.fc31.noarch.rpm   
-   * f31-backgrounds-xfce-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-extras-gnome-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-gnome-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-animated-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-extras-kde-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-kde-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-base-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-extras-mate-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-mate-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-extras-base-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-extras-xfce-32.0.0-1.fc31.noarch.rpm
+   * f32-backgrounds-xfce-32.0.0-1.fc31.noarch.rpm
 
 * You can then change the wallpaper, for example on KDE, right click on the desktop and a menu should appear. Click on the menu and choose *Configure Desktop* then select the icon *Wallpaper* and choose one of the newly installed wallpers.
    

--- a/default/f32-metadata.desktop
+++ b/default/f32-metadata.desktop
@@ -17,7 +17,7 @@ X-Plasma-API=5.0
 FallbackTheme=default
 
 [Wallpaper]
-defaultWallpaperTheme=F31
+defaultWallpaperTheme=F32
 defaultFileSuffix=.png
 defaultWidth=1920
 defaultHeight=1200

--- a/default/f32.xml
+++ b/default/f32.xml
@@ -7,18 +7,8 @@
     <minute>00</minute>
     <second>00</second>
   </starttime>
-<static>
-<duration>10000000000.0</duration>
-<file>
-	<!-- Wide 16:9 -->
-	<size width="1920" height="1080">/usr/share/backgrounds/f32/default/tv-wide/f32.png</size>
-	<!-- Wide 16:10 -->
-	<size width="1920" height="1200">/usr/share/backgrounds/f32/default/wide/f32.png</size>
-	<!-- Standard 4:3 -->
-	<size width="2048" height="1536">/usr/share/backgrounds/f32/default/standard/f32.png</size>
-	<!-- Normalish 5:4 -->
-	<size width="1280" height="1024">/usr/share/backgrounds/f32/default/normalish/f32.png</size>
-</file>
-</static>
-
+  <static>
+    <duration>10000000000.0</duration>
+    <file>/usr/share/backgrounds/f32/default/f32.png</file>
+  </static>
 </background>

--- a/default/f32.xml
+++ b/default/f32.xml
@@ -11,13 +11,13 @@
 <duration>10000000000.0</duration>
 <file>
 	<!-- Wide 16:9 -->
-	<size width="1920" height="1080">/usr/share/backgrounds/f31/default/tv-wide/f31.png</size>
+	<size width="1920" height="1080">/usr/share/backgrounds/f32/default/tv-wide/f32.png</size>
 	<!-- Wide 16:10 -->
-	<size width="1920" height="1200">/usr/share/backgrounds/f31/default/wide/f31.png</size>
+	<size width="1920" height="1200">/usr/share/backgrounds/f32/default/wide/f32.png</size>
 	<!-- Standard 4:3 -->
-	<size width="2048" height="1536">/usr/share/backgrounds/f31/default/standard/f31.png</size>
+	<size width="2048" height="1536">/usr/share/backgrounds/f32/default/standard/f32.png</size>
 	<!-- Normalish 5:4 -->
-	<size width="1280" height="1024">/usr/share/backgrounds/f31/default/normalish/f31.png</size>
+	<size width="1280" height="1024">/usr/share/backgrounds/f32/default/normalish/f32.png</size>
 </file>
 </static>
 


### PR DESCRIPTION
I hope these commits together should make this actually work properly. First, lots of '31' references were not changed to '32', including in both the KDE and GNOME XML files, which will mean both of those still showed F31 backgrounds (or, if f31-backgrounds isn't installed, will probably fall back on something entirely different). Second, the GNOME xml file was not updated for the dropping of the aspect ratio variant files, and was still trying to point to them even though they don't exist any more. I hope I edited it right.