### PR TITLE
Fix "Fix symlink" (RHBZ#1885792)

### DIFF
--- a/default/Makefile
+++ b/default/Makefile
@@ -22,7 +22,7 @@ install:
 	for tod in 01-dawn 02-day 03-dusk 04-night; do \
 	   $(INSTALL) $(WP_NAME)-$${tod}.png	$(WP_DIR)/default/$(WP_NAME)-$${tod}.png ; \
 	done; 
-	$(LN_S) $../default/$(WP_NAME)-02-day.png	$(WP_DIR)/default/$(WP_NAME).png
+	$(LN_S) ../default/$(WP_NAME)-02-day.png	$(WP_DIR)/default/$(WP_NAME).png
 	$(INSTALL) $(WP_NAME).xml	$(WP_DIR)/default/$(WP_NAME).xml 
 	
 	#~ GNOME background


### PR DESCRIPTION
As reported at https://bugzilla.redhat.com/show_bug.cgi?id=1885792
commit 1d5915fc had a typo, mistakenly leaving a stray dollar
sign which caused the resulting symlink to point to the wrong
place. This means we get no background on desktops that use the
f33.png symlink, among them KDE. This should fix the symlink.

Signed-off-by: Adam Williamson <awilliam@redhat.com>