### PR TITLE
Fixing F36 background to appear first in GNOME control-center

### DIFF
--- a/default/gnome-backgrounds-f36.xml
+++ b/default/gnome-backgrounds-f36.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
 <wallpapers>
     <wallpaper deleted="false">
-        <name>Fedora 36 Default</name>
+        <name>Default Background</name>
         <filename>/usr/share/backgrounds/f36/default/f36-01-day.png</filename>
 	<filename-dark>/usr/share/backgrounds/f36/default/f36-02-night.png</filename-dark>
         <options>zoom</options>
@@ -12,7 +12,7 @@
     </wallpaper>
 
     <wallpaper deleted="false">
-        <name>Fedora 36 Time of Day</name>
+        <name>00 Fedora 36 Time of Day</name>
         <filename>/usr/share/backgrounds/f36/default/f36.xml</filename>
         <options>zoom</options>
     </wallpaper>


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gnome-control-center/-/issues/1716 for
background. I changed the F36 default wallpaper to be named "Default Background"
in its XML and I updated the F36 timed background XML to prepend "00 " to its
name in the XML so that it would appear 2nd.