### PR TITLE
default: remove auto-optimalization

### DIFF
--- a/default/Makefile
+++ b/default/Makefile
@@ -9,7 +9,6 @@ MATE_BG_DEFAULT=$(DESTDIR)/usr/share/backgrounds/mate
 PLASMA_BG_DIR=$(DESTDIR)/usr/share/plasma/desktoptheme
 XFCE_BG_DIR=$(DESTDIR)/usr/share/xfce4/backdrops
 INKSCAPE=/usr/bin/inkscape
-PNGQUANT=/usr/bin/pngquant
 MKDIR=/bin/mkdir -p
 INSTALL=/usr/bin/install -p -m644 -D
 LN_S=/bin/ln -s
@@ -19,12 +18,11 @@ all:
 
 install:
 	$(MKDIR) $(WP_DIR)/default
-	#~ Base background and optimization
-	for tod in 01-day 01-night; do \
-		$(PNGQUANT) -o $(WP_DIR)/default/$(WP_NAME)-$${tod}.png \
-			$(WP_NAME)-$${tod}.png ; \
-	done; 
 	$(INSTALL) $(WP_NAME).xml	$(WP_DIR)/default/$(WP_NAME).xml 
+	#~ Base background and optimization
+        for tod in 01-day 01-night; do \
+          $(INSTALL) $(WP_NAME)-$${tod}.png	$(WP_DIR)/default/$(WP_NAME)-$${tod}.png ; \
+        done;
 	
 	#~ GNOME background
 	$(MKDIR) $(GNOME_BG_DIR)

--- a/extras/Makefile
+++ b/extras/Makefile
@@ -38,7 +38,7 @@ install:
 	done;
 	#~ Compress to 8-bit png format
 	for theme in $(THEMES_PNG) ; do \
-	  $(PNGQUANT) -o $(F39_DIR)/extras/$${theme}.png $${theme}.png ;\
+	  $(INSTALL) $${theme}.png     $(F39_DIR)/extras/$${theme}.png ; \
 	  $(MKDIR) $(KDE_BG_DIR)/F39_$${theme}/contents/images ;\
 	  $(INSTALL) $${theme}.desktop $(KDE_BG_DIR)/F39_$${theme}/metadata.desktop ; \
 	  for res in 1280x1024 \


### PR DESCRIPTION
- Right now pngquant will produce 8bit fixed color palette PNGs, which is absolutely not what you want in 95% of cases. No amount of dithering will result in no color banding when the abstract wallpaper is relying on 24 or even 48bit.
- Avoiding color banding with dithering is a deliberate controlled process done during the creation

Fixes https://github.com/fedoradesign/backgrounds/issues/57