### PR TITLE
Convert RGBA-format PNG files during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ WP_INSTALL_ROOT=$(DESTDIR)/usr/share
 WP_REL_PATH=backgrounds/$(WP_NAME)
 
 WP_BG_ROOT=$(WP_INSTALL_ROOT)/$(WP_REL_PATH)
+KDE_BG_ROOT=$(WP_INSTALL_ROOT)/wallpapers/
 GNOME_BG_DIR=$(WP_INSTALL_ROOT)/gnome-background-properties
-KDE_BG_DIR=$(WP_INSTALL_ROOT)/wallpapers/$(WP_BIGNAME)
 MATE_BG_DIR=$(WP_INSTALL_ROOT)/mate-background-properties
 MATE_BG_DEFAULT=$(WP_INSTALL_ROOT)/backgrounds/mate
 PLASMA_BG_DIR=$(WP_INSTALL_ROOT)/plasma/desktoptheme

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,47 @@ SUBDIRS = default
 VERSION = 41.0.0
 NAME =  f41-backgrounds-$(VERSION)
 
-all:
-	@for i in $(SUBDIRS) ; do \
-		(cd $$i; $(MAKE)) ;\
-	done;
+WP_NAME=f41
+WP_BIGNAME=F41
 
-install:
-	@for i in $(SUBDIRS) ; do \
-		(cd $$i; $(MAKE) install) ; \
-	done;
+WP_INSTALL_ROOT=$(DESTDIR)/usr/share
+WP_REL_PATH=backgrounds/$(WP_NAME)
+
+WP_BG_ROOT=$(WP_INSTALL_ROOT)/$(WP_REL_PATH)
+GNOME_BG_DIR=$(WP_INSTALL_ROOT)/gnome-background-properties
+KDE_BG_DIR=$(WP_INSTALL_ROOT)/wallpapers/$(WP_BIGNAME)
+MATE_BG_DIR=$(WP_INSTALL_ROOT)/mate-background-properties
+MATE_BG_DEFAULT=$(WP_INSTALL_ROOT)/backgrounds/mate
+PLASMA_BG_DIR=$(WP_INSTALL_ROOT)/plasma/desktoptheme
+XFCE_BG_DIR=$(WP_INSTALL_ROOT)/xfce4/backdrops
+
+MAGICK=/usr/bin/magick
+MKDIR=/bin/mkdir -p
+INSTALL=/usr/bin/install -p -m644 -D
+LN_S=/bin/ln -s
+CP=/bin/cp -p
+TOUCH_R=/bin/touch -r
+BASENAME=/bin/basename
+
+RESOLUTIONS= \
+	1280x1024 640x480 800x600 1024x768 1152x864 1200x900 \
+	1280x960 1440x1080 1600x1200 1600x1280 1920x1440 2048x1536 \
+	800x480 1024x600 1152x720 1280x720 1280x768 1280x800 \
+	1366x768 1440x900 1680x1050 1920x1080 1920x1200 1920x1280 \
+	2160x1440 2304x1440 2560x1440 2560x1600 2960x1440 \
+	3000x2000 3200x1800 3440x1440 3840x2160
+
+# Pass all variables to sub-makes
+export
+
+.PHONY: $(SUBDIRS) install all
+
+all:
+
+$(SUBDIRS):
+	$(MAKE) -C $@ install
+
+install: $(SUBDIRS)
 
 dist:
 	mkdir -p $(NAME)
@@ -22,4 +54,3 @@ dist:
 	cp -a extras $(NAME)
 	tar -c --xz -f $(NAME).tar.xz $(NAME)
 	rm -rf $(NAME)
-

--- a/default/Makefile
+++ b/default/Makefile
@@ -1,5 +1,6 @@
 WP_BG_DIR=$(WP_BG_ROOT)/default
 WP_BG_REL=$(WP_REL_PATH)/default
+KDE_BG_DIR=$(KDE_BG_ROOT)/$(WP_BIGNAME)
 
 THEMES_PNG= \
 	$(WP_NAME)-01-day.png \

--- a/default/Makefile
+++ b/default/Makefile
@@ -1,56 +1,72 @@
-WP_NAME=f41
-WP_BIGNAME=F41
-WP_DIR=$(DESTDIR)/usr/share/backgrounds/$(WP_NAME)
-WP_DIR_LN=/usr/share/backgrounds/$(WP_NAME)
-GNOME_BG_DIR=$(DESTDIR)/usr/share/gnome-background-properties
-KDE_BG_DIR=$(DESTDIR)/usr/share/wallpapers
-MATE_BG_DIR=$(DESTDIR)/usr/share/mate-background-properties
-MATE_BG_DEFAULT=$(DESTDIR)/usr/share/backgrounds/mate
-PLASMA_BG_DIR=$(DESTDIR)/usr/share/plasma/desktoptheme
-XFCE_BG_DIR=$(DESTDIR)/usr/share/xfce4/backdrops
-INKSCAPE=/usr/bin/inkscape
-MKDIR=/bin/mkdir -p
-INSTALL=/usr/bin/install -p -m644 -D
-LN_S=/bin/ln -s
-CP=/bin/cp -p
+WP_BG_DIR=$(WP_BG_ROOT)/default
+WP_BG_REL=$(WP_REL_PATH)/default
+
+THEMES_PNG= \
+	$(WP_NAME)-01-day.png \
+	$(WP_NAME)-01-night.png
+
+WP_PNG_DESTS=$(THEMES_PNG:%=$(WP_BG_DIR)/%)
+XFCE_PNG_DESTS=$(THEMES_PNG:%=$(XFCE_BG_DIR)/%)
+
+INSTALL_RULES= \
+	install-base \
+	install-gnome \
+	install-budgie \
+	install-kde \
+	install-mate \
+	install-xfce
+
+.PHONY: $(WP_PNG_DESTS) $(XFCE_PNG_DESTS) $(INSTALL_RULES) \
+        all install
+
+$(WP_PNG_DESTS): OUTNAME = $(shell $(BASENAME) $@)
+$(WP_PNG_DESTS):
+	$(MKDIR) $(WP_BG_DIR)
+	#~ Convert to RGB-format file (no alpha) and fix timestamp
+	$(MAGICK) $(OUTNAME) -alpha off $@ 
+	$(TOUCH_R) $(OUTNAME) $@
+
+$(XFCE_PNG_DESTS): OUTNAME = $(shell $(BASENAME) $@)
+$(XFCE_PNG_DESTS):
+	$(MKDIR) $(XFCE_BG_DIR)
+	#~ Convert to RGB-format file (no alpha) and fix timestamp
+	$(MAGICK) $(OUTNAME) -alpha off $@
+	$(TOUCH_R) $(OUTNAME) $@
 
 all:
 
-install:
-	$(MKDIR) $(WP_DIR)/default
-	$(INSTALL) $(WP_NAME).xml	$(WP_DIR)/default/$(WP_NAME).xml
-	#~ Base background
-	for tod in 01-day 01-night; do \
-	  $(INSTALL) $(WP_NAME)-$${tod}.png	$(WP_DIR)/default/$(WP_NAME)-$${tod}.png ; \
-	done;
-	
+install: $(INSTALL_RULES)
+
+install-base: $(WP_PNG_DESTS)
+	$(MKDIR) $(WP_BG_DIR)
+	$(INSTALL) $(WP_NAME).xml	$(WP_BG_DIR)/$(WP_NAME).xml
+	#~ Base background images done by WP_PNG_DESTS rules
+
+install-gnome:	
 	#~ GNOME background
 	$(MKDIR) $(GNOME_BG_DIR)
 	$(INSTALL) gnome-backgrounds-$(WP_NAME).xml	$(GNOME_BG_DIR)/$(WP_NAME).xml
+
+install-budgie:
 	#~ Budgie background
 	$(INSTALL) budgie-backgrounds-$(WP_NAME).xml	$(GNOME_BG_DIR)/$(WP_NAME)-budgie.xml
-	
+
+install-kde:	
 	#~ KDE and Plasma background
-	$(MKDIR) $(KDE_BG_DIR)/$(WP_BIGNAME)/contents/images
-	$(MKDIR) $(KDE_BG_DIR)/$(WP_BIGNAME)/contents/images_dark
-	$(INSTALL) $(WP_NAME)-metadata.json $(KDE_BG_DIR)/$(WP_BIGNAME)/metadata.json
-	for res in 1280x1024 \
-		     640x480 800x600 1024x768 1152x864 1200x900 1280x960 1440x1080 1600x1200 1600x1280 1920x1440 2048x1536 \
-		     800x480 1024x600 1152x720 1280x720 1280x768 1280x800 1366x768 1440x900 1680x1050 1920x1080 1920x1200 1920x1280 \
-		     2160x1440 2304x1440 2560x1440 2560x1600 2960x1440 3000x2000 3200x1800  3440x1440 3840x2160; do \
-	  $(LN_S) ../../../../backgrounds/$(WP_NAME)/default/$(WP_NAME)-01-day.png \
-	          $(KDE_BG_DIR)/$(WP_BIGNAME)/contents/images/$${res}.png ; \
-	  $(LN_S) ../../../../backgrounds/$(WP_NAME)/default/$(WP_NAME)-01-night.png \
-	          $(KDE_BG_DIR)/$(WP_BIGNAME)/contents/images_dark/$${res}.png ; \
+	$(MKDIR) $(KDE_BG_DIR)/contents/images
+	$(MKDIR) $(KDE_BG_DIR)/contents/images_dark
+	$(INSTALL) $(WP_NAME)-metadata.json $(KDE_BG_DIR)/metadata.json
+	for res in $(RESOLUTIONS); do \
+	  $(LN_S) ../../../../$(WP_BG_REL)/$(WP_NAME)-01-day.png \
+	          $(KDE_BG_DIR)/contents/images/$${res}.png ; \
+	  $(LN_S) ../../../../$(WP_BG_REL)/$(WP_NAME)-01-night.png \
+	          $(KDE_BG_DIR)/contents/images_dark/$${res}.png ; \
 	done;
 	
+install-mate:
 	#~ MATE background
 	$(MKDIR) $(MATE_BG_DIR)
 	$(INSTALL) mate-backgrounds-$(WP_NAME).xml $(MATE_BG_DIR)/$(WP_NAME).xml
-	
-	#~ XFCE background
-	$(MKDIR) $(XFCE_BG_DIR)
-	$(INSTALL) $(WP_NAME)-01-day.png \
-			$(XFCE_BG_DIR)/$(WP_NAME).png
-	$(INSTALL) $(WP_NAME)-01-night.png \
-			$(XFCE_BG_DIR)/$(WP_NAME)-01-night.png
+
+install-xfce: $(XFCE_PNG_DESTS)
+	#~ XFCE background images done by XFCE_PNG_DESTS rules

--- a/extras/Makefile
+++ b/extras/Makefile
@@ -1,54 +1,74 @@
-F41_DIR=$(DESTDIR)/usr/share/backgrounds/f41
-GNOME_BG_DIR=$(DESTDIR)/usr/share/gnome-background-properties
-MATE_BG_DIR=$(DESTDIR)/usr/share/mate-background-properties
-KDE_BG_DIR=$(DESTDIR)/usr/share/wallpapers/
-XFCE_BG_DIR=$(DESTDIR)/usr/share/xfce4/backdrops
-MKDIR=/bin/mkdir -p
-PNGQUANT=/usr/bin/pngquant
-INSTALL=/usr/bin/install -p -m644 -D
-LN_S=/bin/ln -s
+WP_BG_DIR=$(WP_BG_ROOT)/extras
+WP_BG_REL=$(WP_REL_PATH)/extras
 
 THEMES_JPG=
-THEMES_PNG=01-dark-blue\
+THEMES_PNG= \
+	01-dark-blue \
 	01-light-blue
+
+WP_PNG_DESTS=$(THEMES_PNG:%=$(WP_BG_DIR)/%.png)
+
+INSTALL_RULES= \
+	install-base \
+	install-gnome \
+	install-kde \
+	install-mate \
+	install-xfce
+
+.PHONY: $(WP_PNG_DESTS) $(INSTALL_RULES) all install
+
+$(WP_PNG_DESTS): OUTNAME = $(shell $(BASENAME) $@)
+$(WP_PNG_DESTS):
+	$(MKDIR) $(WP_BG_DIR)
+	#~ Convert to RGB-format file (no alpha) and fix timestamp
+	$(MAGICK) $(OUTNAME) -alpha off $@ 
+	$(TOUCH_R) $(OUTNAME) $@
 
 all:
 
-install:
-	$(MKDIR) $(F41_DIR)/extras
-	$(MKDIR) $(GNOME_BG_DIR)
-	$(MKDIR) $(MATE_BG_DIR)
-	$(MKDIR) $(XFCE_BG_DIR)
-	$(INSTALL) f41-extras.xml 				$(F41_DIR)/extras/f41-extras.xml
-	$(INSTALL) gnome-backgrounds-f41-extras.xml 	$(GNOME_BG_DIR)/f41-extras.xml
-	$(INSTALL) mate-backgrounds-f41-extras.xml 	$(MATE_BG_DIR)/f41-extras.xml
-	for theme in $(THEMES_JPG) ; do \
-	  $(INSTALL) $${theme}.jpg $(F41_DIR)/extras/$${theme}.jpg ;\
-	  $(MKDIR) $(KDE_BG_DIR)/F41_$${theme}/contents/images ;\
-	  $(INSTALL) $${theme}.desktop $(KDE_BG_DIR)/F41_$${theme}/metadata.desktop ; \
-	  for res in 1280x1024 \
-		     640x480 800x600 1024x768 1152x864 1200x900 1280x960 1440x1080 1600x1200 1600x1280 1920x1440 2048x1536 \
-		     800x480 1024x600 1152x720 1280x720 1280x768 1280x800 1366x768 1440x900 1680x1050 1920x1080 1920x1200 \
-		     2160x1440 2304x1440 2560x1440 2560x1600 2960x1440 3000x2000 3200x1800  3440x1440 3840x2160; do \
-	    $(LN_S) ../../../../backgrounds/f41/extras/$${theme}.jpg \
-	            $(KDE_BG_DIR)/F41_$${theme}/contents/images/$${res}.jpg ; \
-	  done; \
-	  $(LN_S) ../../backgrounds/f41/extras/$${theme}.jpg \
-			$(XFCE_BG_DIR)/f41-$${theme}.jpg ;\
-	done;
-	#~ Compress to 8-bit png format
-	for theme in $(THEMES_PNG) ; do \
-	  $(INSTALL) $${theme}.png     $(F41_DIR)/extras/$${theme}.png ; \
-	  $(MKDIR) $(KDE_BG_DIR)/F41_$${theme}/contents/images ;\
-	  $(INSTALL) $${theme}.desktop $(KDE_BG_DIR)/F41_$${theme}/metadata.desktop ; \
-	  for res in 1280x1024 \
-		     640x480 800x600 1024x768 1152x864 1200x900 1280x960 1440x1080 1600x1200 1600x1280 1920x1440 2048x1536 \
-		     800x480 1024x600 1152x720 1280x720 1280x768 1280x800 1366x768 1440x900 1680x1050 1920x1080 1920x1200 \
-		     2160x1440 2304x1440 2560x1440 2560x1600 2960x1440 3000x2000 3200x1800  3440x1440 3840x2160; do \
-	    $(LN_S) ../../../../backgrounds/f41/extras/$${theme}.png \
-	            $(KDE_BG_DIR)/F41_$${theme}/contents/images/$${res}.png ; \
-	  done; \
-	  $(LN_S) ../../backgrounds/f41/extras/$${theme}.png \
-			$(XFCE_BG_DIR)/f41-$${theme}.png ;\
-	done;
+install: $(INSTALL_RULES)
 
+install-base: $(WP_PNG_DESTS)
+	$(MKDIR) $(WP_BG_DIR)
+	$(INSTALL) f41-extras.xml $(WP_BG_DIR)/f41-extras.xml
+	for theme in $(THEMES_JPG); do \
+	  $(INSTALL) $${theme}.jpg $(WP_BG_DIR)/$${theme}.jpg; \
+	done
+	#~ Base background PNG images done by WP_PNG_DESTS rules
+
+install-gnome:
+	$(MKDIR) $(GNOME_BG_DIR)
+	$(INSTALL) gnome-backgrounds-f41-extras.xml $(GNOME_BG_DIR)/f41-extras.xml
+
+install-mate:
+	$(MKDIR) $(MATE_BG_DIR)
+	$(INSTALL) mate-backgrounds-f41-extras.xml $(MATE_BG_DIR)/f41-extras.xml
+
+install-xfce:
+	$(MKDIR) $(XFCE_BG_DIR)
+	for theme in $(THEMES_JPG); do \
+	  $(LN_S) ../../$(WP_BG_REL)/$${theme}.jpg \
+			$(XFCE_BG_DIR)/f41-$${theme}.jpg ;\
+	done
+	for theme in $(THEMES_PNG); do \
+	  $(LN_S) ../../$(WP_BG_REL)/$${theme}.png \
+			$(XFCE_BG_DIR)/f41-$${theme}.png ; \
+	done
+
+install-kde:
+	for theme in $(THEMES_JPG) ; do \
+	  $(MKDIR) $(KDE_BG_DIR)/F41_$${theme}/contents/images ;\
+	  $(INSTALL) $${theme}.desktop $(KDE_BG_DIR)/F41_$${theme}/metadata.desktop ; \
+	  for res in $(RESOLUTIONS); do \
+	    $(LN_S) ../../../../../$(WP_BG_REL)/$${theme}.jpg \
+	      $(KDE_BG_DIR)/F41_$${theme}/contents/images/$${res}.jpg ; \
+	  done; \
+	done;
+	for theme in $(THEMES_PNG) ; do \
+	  $(MKDIR) $(KDE_BG_DIR)/F41_$${theme}/contents/images ;\
+	  $(INSTALL) $${theme}.desktop $(KDE_BG_DIR)/F41_$${theme}/metadata.desktop ; \
+	  for res in $(RESOLUTIONS); do \
+	    $(LN_S) ../../../../../$(WP_BG_REL)/$${theme}.png \
+	      $(KDE_BG_DIR)/F41_$${theme}/contents/images/$${res}.png ; \
+	  done; \
+	done;

--- a/extras/Makefile
+++ b/extras/Makefile
@@ -48,11 +48,11 @@ install-xfce:
 	$(MKDIR) $(XFCE_BG_DIR)
 	for theme in $(THEMES_JPG); do \
 	  $(LN_S) ../../$(WP_BG_REL)/$${theme}.jpg \
-			$(XFCE_BG_DIR)/f41-$${theme}.jpg ;\
+			$(XFCE_BG_DIR)/f41-extras-$${theme}.jpg ;\
 	done
 	for theme in $(THEMES_PNG); do \
 	  $(LN_S) ../../$(WP_BG_REL)/$${theme}.png \
-			$(XFCE_BG_DIR)/f41-$${theme}.png ; \
+			$(XFCE_BG_DIR)/f41-extras-$${theme}.png ; \
 	done
 
 install-kde:

--- a/extras/Makefile
+++ b/extras/Makefile
@@ -57,18 +57,18 @@ install-xfce:
 
 install-kde:
 	for theme in $(THEMES_JPG) ; do \
-	  $(MKDIR) $(KDE_BG_DIR)/F41_$${theme}/contents/images ;\
-	  $(INSTALL) $${theme}.desktop $(KDE_BG_DIR)/F41_$${theme}/metadata.desktop ; \
+	  $(MKDIR) $(KDE_BG_ROOT)/F41_$${theme}/contents/images ;\
+	  $(INSTALL) $${theme}.desktop $(KDE_BG_ROOT)/F41_$${theme}/metadata.desktop ; \
 	  for res in $(RESOLUTIONS); do \
-	    $(LN_S) ../../../../../$(WP_BG_REL)/$${theme}.jpg \
-	      $(KDE_BG_DIR)/F41_$${theme}/contents/images/$${res}.jpg ; \
+	    $(LN_S) ../../../../$(WP_BG_REL)/$${theme}.jpg \
+	      $(KDE_BG_ROOT)/F41_$${theme}/contents/images/$${res}.jpg ; \
 	  done; \
 	done;
 	for theme in $(THEMES_PNG) ; do \
-	  $(MKDIR) $(KDE_BG_DIR)/F41_$${theme}/contents/images ;\
-	  $(INSTALL) $${theme}.desktop $(KDE_BG_DIR)/F41_$${theme}/metadata.desktop ; \
+	  $(MKDIR) $(KDE_BG_ROOT)/F41_$${theme}/contents/images ;\
+	  $(INSTALL) $${theme}.desktop $(KDE_BG_ROOT)/F41_$${theme}/metadata.desktop ; \
 	  for res in $(RESOLUTIONS); do \
-	    $(LN_S) ../../../../../$(WP_BG_REL)/$${theme}.png \
-	      $(KDE_BG_DIR)/F41_$${theme}/contents/images/$${res}.png ; \
+	    $(LN_S) ../../../../$(WP_BG_REL)/$${theme}.png \
+	      $(KDE_BG_ROOT)/F41_$${theme}/contents/images/$${res}.png ; \
 	  done; \
 	done;

--- a/f41-backgrounds.spec
+++ b/f41-backgrounds.spec
@@ -2,8 +2,8 @@
 %global Bg_Name F41
 %global bgname %(t="%{Bg_Name}";echo ${t,,})
 
-# Disable Extras subpackages
-%global with_extras 0
+# Disable Extras subpackages by default
+%bcond_with extras
 
 Name:           %{bgname}-backgrounds
 Version:        %{relnum}.0.0
@@ -83,7 +83,7 @@ Requires:       xfdesktop
 This package contains XFCE4 desktop background for the Fedora  %{relnum}
 default theme.
 
-%if %{with_extras}
+%if %{with extras}
 %package        extras-base
 Summary:        Base images for  Extras Backgrounds
 License:        CC-BY-4.0 AND CC-BY-SA-4.0 AND CC0-1.0
@@ -131,11 +131,11 @@ This package contains  supplemental wallpapers for XFCE
 
 
 %build
-%make_build
+%make_build %{?with_extras:SUBDIRS="default extras"}
 
 
 %install
-%make_install
+%make_install %{?with_extras:SUBDIRS="default extras"}
 
 %files
 %doc
@@ -162,15 +162,15 @@ This package contains  supplemental wallpapers for XFCE
 
 %files xfce
 %{_datadir}/xfce4/backdrops/%{bgname}*.png
-%if %{with_extras}
+%if %{with extras}
 %exclude %{_datadir}/xfce4/backdrops/%{bgname}-extras*.png
 %endif
 %dir %{_datadir}/xfce4/
 %dir %{_datadir}/xfce4/backdrops/
 
-%if %{with_extras}
+%if %{with extras}
 %files extras-base
-%license COPYING
+%license CC-BY-SA-4.0 Attribution
 %{_datadir}/backgrounds/%{bgname}/extras/
 
 %files extras-gnome

--- a/f41-backgrounds.spec
+++ b/f41-backgrounds.spec
@@ -127,7 +127,7 @@ This package contains  supplemental wallpapers for XFCE
 %endif
 
 %prep
-%autosetup -n %{name}
+%autosetup -n %{name}-%{version}
 
 
 %build
@@ -141,7 +141,7 @@ This package contains  supplemental wallpapers for XFCE
 %doc
 
 %files base
-%license COPYING Attribution
+%license CC-BY-SA-4.0 Attribution
 %dir %{_datadir}/backgrounds/%{bgname}
 %dir %{_datadir}/backgrounds/%{bgname}/default
 %{_datadir}/backgrounds/%{bgname}/default/%{bgname}*.{png,xml}

--- a/f41-backgrounds.spec
+++ b/f41-backgrounds.spec
@@ -19,6 +19,7 @@ BuildArch:      noarch
 
 BuildRequires:  kde-filesystem
 BuildRequires:  make
+BuildRequires:  ImageMagick
 
 Requires:       %{name}-budgie = %{version}-%{release}
 Requires:       %{name}-gnome = %{version}-%{release}

--- a/f41-backgrounds.spec
+++ b/f41-backgrounds.spec
@@ -161,7 +161,10 @@ This package contains  supplemental wallpapers for XFCE
 %dir %{_datadir}/mate-background-properties/
 
 %files xfce
-%{_datadir}/xfce4/backdrops/%{bgname}.png
+%{_datadir}/xfce4/backdrops/%{bgname}*.png
+%if %{with_extras}
+%exclude %{_datadir}/xfce4/backdrops/%{bgname}-extras*.png
+%endif
 %dir %{_datadir}/xfce4/
 %dir %{_datadir}/xfce4/backdrops/
 
@@ -180,7 +183,7 @@ This package contains  supplemental wallpapers for XFCE
 %{_datadir}/mate-background-properties/%{bgname}-extras.xml
 
 %files extras-xfce
-%{_datadir}/xfce4/backdrops/
+%{_datadir}/xfce4/backdrops/%{bgname}-extras*.png
 %endif
 
 %changelog


### PR DESCRIPTION
This PR is the first of two possible solutions to the issue of RGBA-format PNG files making their way into the repo. Files with an alpha channel cause problems for the GNOME Shell animated backgrounds code, so they need to be converted to RGB for the transitions to display properly. (See #51, #67.)

This PR addresses that by using ImageMagick to process the files as they're being installed, ensuring that only images without an alpha channel are installed, no matter what format the repo's source images are in.

As such, it does add ImageMagick as a new build dependency for the repo.

These commits also represent a general updating and enhancing of the entire build process, which IMHO are useful with or without the ImageMagick processing. And if we decide not to go this route, I can drop the conversion rules from this PR and leave the rest of the fixes in place.) Notable changes include:

### Makefile(s)
- Use recommended[1] recursion via phony subdir rules and `$(MAKE) -C`, instead of scripted loop. Installs can now be run in parallel with `make install -jN` (though this would only have any effect if both of the `default/` and `extras/` directories were being installed together.)
- Move most variables to top-level Makefile, and `export` to sub-makes so they can be shared between the two paths.
- Break each Makefile's `install` rule up into `install-base` plus a set of `install-(DE)` rules, one for each Desktop Environment. All `install-*` rules are prerequisites of the main `install` rule.

### `f41-backgrounds.spec`
- Updated to add `ImageMagick` as a BuildRequires.
- Turned `with_extras` into a real `bcond_with`, so that installation of the `extras/` dir can be activated with `rpmbuild ... --with extras`
- Fixed the handling of `with_extras` so that activating it has the proper effect
- Corrected the name of the license file installable from the repo

### Installed image filenames (XFCE package)

The XFCE files are all installed to the same directory. Previously, the Makefile installed the images/symlinks as follows:
- From the `default/` directory:
    `01-day.png` was installed (by copying) as `f41.png`
    `01-night.png` was installed (by copying) as `f41-01-night.png`
- From the `extras/` directory:
    `01-dark-blue.png` was symlinked as `f41-01-dark-blue.png`
    `01-light-blue.png` was symlinked as `f41-01-light-blue.png`

(I have no idea why some are copied and others are symlinked, seems like the `default/` files could be symlinked as well. I can easily change that if it's useful, but I've left it the way it is so far.)

...And then in the spec file, only `f41.png` was packaged in `f41-backgrounds-xfce4`, with the rest (including the default dark image) theoretically going into `f41-backgrounds-extras-xfce4` if that weren't hardcoded as disabled.

Because the ImageMagick processing rules don't lend themselves to renaming the output file like that, and because it didn't really make sense to me that only _one_ of the two default theme files was being packaged in the `-xfce4` subpackage, this PR changes the install so that:
  `01-day.png` is installed as `f41-01-day.png`
  `01-night.png` is installed as `f41-01-night.png`
  `01-dark-blue.png` is symlinked as `f41-extras-01-dark-blue.png`
  `01-light-blue.png` is symlinked as `f41-extras-01-light-blue.png`

The spec file will now create the main -xfce subpackage to contain `f41*.png`, _excluding_ `f41-extras*.png` (if `with_extras` is enabled). The excluded files will go into the `-extras-xfce` subpackage instead. This seems more consistent, and doesn't relegate the f41 dark background to second-class status.

So, this PR _does_ change the installed name of the XFCE background (from `f41.png` to `f41-01-day.png`, but it also provides the `f41-01-night.png` image that's included for all other DEs, but was being left out of the XFCE package for some reason.

#### `RESOLUTIONS`

While I was combining the redundant variables from the two directories' Makefiles, I noticed that the list of resolutions being used in the `extras/` dir had **one additional size** in the list, that wasn't present in the `defaults/` directory's Makefile.

That size is `1920x1280`, which is a **very** weird resolution that I've personally never seen or heard of on any screen I've used. So, maybe it was an error that had been corrected in `defaults/` but not in `extras/`. In any case, because I used the more complete list it's now present in the set of symlinks created from both Makefiles — if it shouldn't be there, let me know and I'll remove it.

[1]: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html

Fixes #67